### PR TITLE
Fix version file syntax

### DIFF
--- a/BeamedPowerStandalone.version
+++ b/BeamedPowerStandalone.version
@@ -1,6 +1,6 @@
 {
-    "NAME":"BeamedPowerStandalone"
-    "URL":"https://github.com/AniruddhKSP/KSP-Beamed-Power-Standalone-mod/blob/master/BeamedPowerStandalone.version",
+    "NAME":"BeamedPowerStandalone",
+    "URL":"https://github.com/AniruddhKSP/KSP-Beamed-Power-Standalone-mod/raw/master/BeamedPowerStandalone.version",
     "DOWNLOAD":"https://spacedock.info/mod/2492/Beamed%20Power%20Plugin",
     "VERSION":
     {


### PR DESCRIPTION
- There's a missing comma between NAME and URL
- Updated URL to the "raw" form for GitHub, CKAN should be able to translate it automatically but this way is technically more correct

Noticed while reviewing KSP-CKAN/NetKAN#8212.